### PR TITLE
KORG-525 Fix Gutenberg handler

### DIFF
--- a/class-archiveless.php
+++ b/class-archiveless.php
@@ -214,7 +214,7 @@ class Archiveless {
 		if ( 'publish' === $post_object->post_status ) {
 			// If we have a post id and the value of the archiveless is ''.
 			// If empty assume checking field. Rest at a delay from Classic.
-			if ( ! empty( $post_id ) && '1' !== get_post_meta( $post_id, self::$meta_key, true ) ) {
+			if ( ! empty( $post_id ) && '1' === get_post_meta( $post_id, self::$meta_key, true ) ) {
 				$post_object->post_status = self::$status;
 			}
 		} elseif ( self::$status === $post_object->post_status ) {

--- a/class-archiveless.php
+++ b/class-archiveless.php
@@ -248,8 +248,9 @@ class Archiveless {
 	 * @param  int $post_id Post ID.
 	 */
 	public function save_post( $post_id ) {
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST[ self::$meta_key ] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
 			update_post_meta( $post_id, self::$meta_key, intval( $_POST[ self::$meta_key ] ) );
 		}
 	}


### PR DESCRIPTION
* Change method for updating post status to hook in on meta update rather than on post save, as relying on post save doesn't work properly in Gutenberg and can result in off-by-one errors.
* Removes Gutenberg-specific method of updating post status using the REST API because it can result in off-by-one errors.
* Introduces a filter for REST responses for all public post types that overrides the value of post status to be `publish` if the post status is `archiveless` to fix a bug in Gutenberg where it appears that the post is unpublished because it's status is not literally `publish`.
* Since we removed the post save handler, adds a handler for post status transition to handle future posts.