### PR TITLE
KORG-579 Hotfixes

### DIFF
--- a/class-archiveless.php
+++ b/class-archiveless.php
@@ -78,6 +78,7 @@ class Archiveless {
 		add_action( 'init', array( $this, 'register_post_status' ) );
 		add_action( 'init', array( $this, 'register_post_meta' ) );
 		add_action( 'transition_post_status', array( $this, 'transition_post_status' ), 10, 3 );
+		add_action( 'added_post_meta', array( $this, 'updated_post_meta' ), 10, 4 );
 		add_action( 'updated_post_meta', array( $this, 'updated_post_meta' ), 10, 4 );
 
 		// Override the post status in the REST response to avoid Gutenbugs.
@@ -233,7 +234,7 @@ class Archiveless {
 	 */
 	public function transition_post_status( $new_status, $old_status, $post ) {
 		// Only fire if transitioning to publish.
-		if ( 'publish' !== $new_status ) {
+		if ( 'publish' !== $new_status || $new_status === $old_status ) {
 			return;
 		}
 

--- a/class-archiveless.php
+++ b/class-archiveless.php
@@ -146,6 +146,11 @@ class Archiveless {
 	 */
 	public function add_ui() {
 		global $post;
+
+		// Ensure there is a post ID before attempting to look up postmeta.
+		if ( empty( $post->ID ) ) {
+			return;
+		}
 		?>
 		<div class="misc-pub-section">
 			<input type="hidden" name="<?php echo esc_attr( self::$meta_key ); ?>" value="0" />
@@ -262,6 +267,12 @@ class Archiveless {
 	 */
 	public function fool_edit_form() {
 		global $post;
+
+		// Ensure there is a post status before attempting to set it.
+		if ( empty( $post->post_status ) ) {
+			return;
+		}
+
 		if ( self::$status === $post->post_status ) {
 			$post->post_status = 'publish';
 		}
@@ -339,6 +350,11 @@ class Archiveless {
 	 */
 	public function no_index() {
 		global $post;
+
+		// Ensure there is a post ID before attempting to look up postmeta.
+		if ( empty( $post->ID ) ) {
+			return;
+		}
 
 		if ( '1' === get_post_meta( $post->ID, self::$meta_key, true ) ) {
 			echo '<meta name="robots" content="noindex,nofollow" />';

--- a/class-archiveless.php
+++ b/class-archiveless.php
@@ -232,8 +232,8 @@ class Archiveless {
 	 * @param WP_Post $post       Post object.
 	 */
 	public function transition_post_status( $new_status, $old_status, $post ) {
-		// Only fire if transitioning from future to publish.
-		if ( 'future' !== $old_status || 'publish' !== $new_status ) {
+		// Only fire if transitioning to publish.
+		if ( 'publish' !== $new_status ) {
 			return;
 		}
 

--- a/tests/test-general.php
+++ b/tests/test-general.php
@@ -90,5 +90,32 @@ class ArchivelessTest extends WP_UnitTestCase {
 		// Verify that the post transitioned to 'archiveless' (due to the post meta)
 		$this->assertEquals( 'archiveless', get_post_status( $post_id ) );
 	}
+
+	/**
+	 * Ensures that the post status updates successfully when the archiveless
+	 * post meta is added or updated.
+	 */
+	public function test_post_meta_hooks() {
+		// Create a post.
+		$post_id = $this->factory->post->create( array(
+			'post_title' => 'Test Archiveless Post',
+			'post_status' => 'publish',
+		) );
+
+		// Verify that the post status is 'publish'.
+		$this->assertEquals( 'publish', get_post_status( $post_id ) );
+
+		// Add the archiveless postmeta (rather than updating it) and ensure the post status changes.
+		add_post_meta( $post_id, 'archiveless', '1' );
+		$this->assertEquals( 'archiveless', get_post_status( $post_id ) );
+
+		// Update the post meta value and ensure it changes back to publish.
+		update_post_meta( $post_id, 'archiveless', '0' );
+		$this->assertEquals( 'publish', get_post_status( $post_id ) );
+
+		// Update the post meta value and ensure it changes back to archiveless.
+		update_post_meta( $post_id, 'archiveless', '1' );
+		$this->assertEquals( 'archiveless', get_post_status( $post_id ) );
+	}
 }
 


### PR DESCRIPTION
* In addition to checking and updating the post status when postmeta is updated, also perform the check when postmeta is added. This fixes a bug whereby posts that are created using Gutenberg and saved via the REST API don't trigger the postmeta update hook, since they are being added for the first time.
* Adds a unit test to validate the behavior of the add and update postmeta hooks.
* Fixes a number of notices relating to undefined keys in contexts where the global post object may be empty.
* Modifies the logic for the transition post hook to be more inclusive and not only run on future post status transitions, but all post status transitions where the post stati are different and the new status is 'publish'.