### PR TITLE
DELTA-911: Post type has support for the custom-fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ services:
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
 
-
 # Specify when Travis should build.
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Archiveless
 
-Tested to WP 5.3.2.
+Tested to WP 5.5
 
 Hide WordPress posts from archives, which includes the index page, search results, date archives, author archives, and term lists.
 

--- a/class-archiveless.php
+++ b/class-archiveless.php
@@ -55,7 +55,8 @@ class Archiveless {
 	}
 
 	/**
-	 * Determine if gutenberg editor exists.
+	 * Determine if gutenberg editor exists and
+	 * the post type has support for the `custom-fields`.
 	 *
 	 * @return boolean
 	 */
@@ -64,8 +65,11 @@ class Archiveless {
 
 		// Do we have access to current screen?
 		if ( did_action( 'current_screen' ) && is_admin() ) {
-			$current_screen  = get_current_screen();
-			$is_block_editor = $current_screen instanceof WP_Screen ? $current_screen->is_block_editor : false;
+			$current_screen = get_current_screen();
+
+			if ( $current_screen instanceof WP_Screen && post_type_supports( $current_screen->post_type, 'custom-fields' ) ) {
+				$is_block_editor = wp_validate_boolean( $current_screen->is_block_editor );
+			}
 		}
 
 		return $is_block_editor;


### PR DESCRIPTION
The post type needs support to the `custom-fields` otherwise the Gutenberg editor won't save the field.