### PR TITLE
Add composer.json describing the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .idea
+
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "alleyinteractive/archiveless",
+    "description": "WordPress plugin to hide posts from archives (lists)",
+    "homepage": "https://github.com/alleyinteractive/archiveless",
+    "type": "wordpress-plugin",
+    "license": "GPL-3.0-or-later",
+    "authors": [
+        {
+            "name": "Alley",
+            "email": "noreply@alley.co"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/alleyinteractive/archiveless/issues",
+        "source": "https://github.com/alleyinteractive/archiveless"
+    }
+}


### PR DESCRIPTION
- Adds a composer.json file describing this package with a type of `wordpress-plugin` so that it can be installed and managed via Composer.