### PR TITLE
Include archiveless posts in a post_status any query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this plugin will be documented in this file.
 
+## 1.0.1
+
+- Bug fix from previous use of the archiveless plugin that broke backwards
+  compatibility: only include archiveless posts when no `post_status` is
+  specified for the query. For `get_posts()` calls, this means that archiveless
+  posts will never be included by default since `get_posts()` sets a default
+  post status. To include archiveless posts with `get_posts()`, you can include
+  `archiveless` in the `post_status` or pass `include_archiveless` set to `true.
+- Introduces `include_archiveless` query paramater.
+
 ## 1.0.0
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ add_action(
 
 Queries made with `get_posts()` will always exclude archiveless posts by default
 since `get_posts()` sets a default `post_status` of `publish`. To include
-archiveless posts, you can specify the `post_status` of `[ 'publish',
-'archiveless' ]` or pass `include_archiveless` set to true:
+archiveless posts, you can specify the `post_status` of `any`, declare the
+`post_status` explicitly with `[ 'publish', 'archiveless' ]`, or pass
+`include_archiveless` set to true:
 
 ```php
 // $post_ids will include archiveless posts.
@@ -57,6 +58,15 @@ $post_ids = get_posts(
     'fields'              => 'ids',
     'include_archiveless' => true,
     'suppress_filters'    => false,
+  ]
+);
+
+// Or declare the post_status explicitly.
+$post_ids = get_posts(
+  [
+    'fields'              => 'ids',
+    'suppress_filters'    => false,
+    'post_status'         => [ 'archiveless', 'publish' ],
   ]
 );
 ```

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ older content that shouldn't appear in search results because it is untimely.
 
 ## Usage
 
-By default, the plugin will prevent archiveless posts from appearing on page.
-This is limited to the [main
+By default, the plugin will prevent archiveless posts from appearing on the page. This is limited to the [main
 query](https://developer.wordpress.org/reference/functions/is_main_query/) of
 the page. It will not affect other queries by default.
 
@@ -26,11 +25,9 @@ Archiveless posts can be excluded from normal queries by passing
 `exclude_archiveless`:
 
 ```php
-// Via get_posts()/WP_Query.
-$posts = get_posts(
+$query = new WP_Query(
   [
     'exclude_archiveless' => true,
-    'suppress_filters'    => false,
     // ...
   ]
 );
@@ -43,6 +40,24 @@ add_action(
       $query->set( 'exclude_archiveless', true );
     }
   }
+);
+```
+
+### Handling archiveless posts with `get_posts()` calls
+
+Queries made with `get_posts()` will always exclude archiveless posts by default
+since `get_posts()` sets a default `post_status` of `publish`. To include
+archiveless posts, you can specify the `post_status` of `[ 'publish',
+'archiveless' ]` or pass `include_archiveless` set to true:
+
+```php
+// $post_ids will include archiveless posts.
+$post_ids = get_posts(
+  [
+    'fields'              => 'ids',
+    'include_archiveless' => true,
+    'suppress_filters'    => false,
+  ]
 );
 ```
 

--- a/inc/class-archiveless.php
+++ b/inc/class-archiveless.php
@@ -337,11 +337,6 @@ class Archiveless {
 			return;
 		}
 
-		// Ignore any query for archiveless post specifically.
-		if ( ! empty( $query->get( 'post_status' ) ) && self::$status === $query->get( 'post_status' ) ) {
-			return;
-		}
-
 		$post_statuses = $this->get_default_post_statuses( $query );
 
 		// Determine if archiveless posts should be included or excluded from

--- a/inc/class-archiveless.php
+++ b/inc/class-archiveless.php
@@ -333,16 +333,19 @@ class Archiveless {
 		/**
 		 * Don't modify the query if the post_status is set.
 		 *
-		 * A `post_status` of 'publish' is ignored since get_post() sets 'publish'
-		 * as the default post_status value when not defined.
-		 *
 		 * A `post_status` of 'any' is ignored since we need to include archiveless
 		 * posts because the post_status will be excluded by default (the post
 		 * status is set to be excluded from search).
+		 *
+		 * `get_posts()` will set a default `post_status` of `publish` that is
+		 * respected. To include archiveless posts, set `post_status` to
+		 * `['publish', 'archiveless']` or pass `include_archiveless` as true.
 		 */
 		if (
 			! empty( $query->get( 'post_status' ) )
-			&& ! in_array( $query->get( 'post_status' ), [ 'publish', 'any' ], true )
+			&& 'any' !== $query->get( 'post_status' )
+			&& ! isset( $query->query_vars['include_archiveless'] )
+			&& ! isset( $query->query_vars['exclude_archiveless'] )
 		) {
 			return;
 		}
@@ -354,6 +357,7 @@ class Archiveless {
 		if (
 			( $query->is_main_query() && $query->is_singular() )
 			|| ( ! $query->is_main_query() && ! $query->get( 'exclude_archiveless' ) )
+			|| $query->get( 'include_archiveless' )
 		) {
 			$query->set(
 				'post_status',

--- a/inc/class-archiveless.php
+++ b/inc/class-archiveless.php
@@ -380,7 +380,6 @@ class Archiveless {
 			get_post_stati(
 				[
 					'exclude_from_search' => false,
-					'publicly_queryable'  => true,
 				]
 			)
 		);

--- a/inc/class-archiveless.php
+++ b/inc/class-archiveless.php
@@ -380,13 +380,24 @@ class Archiveless {
 	 * @return string[]
 	 */
 	public function get_default_post_statuses( $query ) {
-		return array_keys(
-			get_post_stati(
-				[
-					'exclude_from_search' => false,
-				]
+		$post_statuses = $query->get( 'post_status', [] );
+
+		if ( ! is_array( $post_statuses ) ) {
+			$post_statuses = explode( ',', $post_statuses );
+		}
+
+		$post_statuses = array_merge(
+			$post_statuses,
+			array_keys(
+				get_post_stati(
+					[
+						'exclude_from_search' => false,
+					]
+				)
 			)
 		);
+
+		return array_values( array_unique( $post_statuses ) );
 	}
 
 	/**

--- a/inc/class-archiveless.php
+++ b/inc/class-archiveless.php
@@ -330,10 +330,20 @@ class Archiveless {
 			return;
 		}
 
-		// Don't modify the query if the post_status is set. A status of 'publish'
-		// is ignored since get_post() sets 'publish' as the default post_status
-		// value when not defined.
-		if ( ! empty( $query->get( 'post_status' ) ) && 'publish' !== $query->get( 'post_status' ) ) {
+		/**
+		 * Don't modify the query if the post_status is set.
+		 *
+		 * A `post_status` of 'publish' is ignored since get_post() sets 'publish'
+		 * as the default post_status value when not defined.
+		 *
+		 * A `post_status` of 'any' is ignored since we need to include archiveless
+		 * posts because the post_status will be excluded by default (the post
+		 * status is set to be excluded from search).
+		 */
+		if (
+			! empty( $query->get( 'post_status' ) )
+			&& ! in_array( $query->get( 'post_status' ), [ 'publish', 'any' ], true )
+		) {
 			return;
 		}
 

--- a/inc/class-archiveless.php
+++ b/inc/class-archiveless.php
@@ -330,14 +330,15 @@ class Archiveless {
 			return;
 		}
 
-		// Don't modify the query if the post_status is set. A status of 'any'
-		// or 'publish' is ignored since get_post() sets 'publish' as the
-		// default post_status value when not defined.
-		if (
-			! empty( $query->get( 'post_status' ) )
-			&& 'any' !== $query->get( 'post_status' )
-			&& 'publish' !== $query->get( 'post_status' )
-		) {
+		// Don't modify the query if the post_status is set. A status of 'publish'
+		// is ignored since get_post() sets 'publish' as the default post_status
+		// value when not defined.
+		if ( ! empty( $query->get( 'post_status' ) ) && 'publish' !== $query->get( 'post_status' ) ) {
+			return;
+		}
+
+		// Ignore any query for archiveless post specifically.
+		if ( ! empty( $query->get( 'post_status' ) ) && self::$status === $query->get( 'post_status' ) ) {
 			return;
 		}
 

--- a/tests/test-general.php
+++ b/tests/test-general.php
@@ -182,6 +182,20 @@ class Test_General extends Test_Case {
 		$this->assertContains( $this->archiveable_post, $post_ids );
 	}
 
+	public function test_always_included_outside_of_main_query_with_post_status_any_with_get_posts() {
+		$post_ids = get_posts(
+			[
+				'fields'           => 'ids',
+				'posts_per_page'   => 100,
+				'suppress_filters' => false,
+				'post_status'      => 'any',
+			]
+		);
+
+		$this->assertContains( $this->archiveless_post, $post_ids );
+		$this->assertContains( $this->archiveable_post, $post_ids );
+	}
+
 	public function test_query_archiveless_posts_only() {
 		$post_ids = $this->query(
 			[

--- a/tests/test-general.php
+++ b/tests/test-general.php
@@ -91,12 +91,26 @@ class Test_General extends Test_Case {
 		$this->assertFalse( Archiveless::is( get_post( $this->archiveable_post ) ) );
 	}
 
-	public function test_always_included_outside_of_main_query() {
+	public function test_always_included_outside_of_main_query_by_default() {
 		$post_ids = get_posts(
 			[
 				'fields'           => 'ids',
 				'posts_per_page'   => 100,
 				'suppress_filters' => false,
+			]
+		);
+
+		$this->assertContains( $this->archiveless_post, $post_ids );
+		$this->assertContains( $this->archiveable_post, $post_ids );
+	}
+
+	public function test_always_included_outside_of_main_query_with_post_status_any() {
+		$post_ids = get_posts(
+			[
+				'fields'           => 'ids',
+				'posts_per_page'   => 100,
+				'suppress_filters' => false,
+				'post_status'      => 'any',
 			]
 		);
 
@@ -118,7 +132,7 @@ class Test_General extends Test_Case {
 		$this->assertNotContains( $this->archiveable_post, $post_ids );
 	}
 
-	public function test_optionally_excluded_outside_of_main_query() {
+	public function test_optionally_excluded_outside_of_main_query_with_exclude_archiveless() {
 		$post_ids = get_posts(
 			[
 				'exclude_archiveless' => true,


### PR DESCRIPTION
- Ensure that when `any` is passed as the `post_status` that archiveless does not modify the query. The query should return archiveless posts normally then with an unmodified query.
- Call out that `get_posts()` calls will not have archiveless posts returned by default. This logic in the plugin broke backward compatibility with some existing plugin use. 