### PR TITLE
Update nodejs from v16 to v19, npm from v8 to v9.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,8 @@
         "webpack-stats-plugin": "^1.0.3"
       },
       "engines": {
-        "node": "16",
-        "npm": "8"
+        "node": "19",
+        "npm": "9"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "license": "GPL-3.0-or-later",
   "engines": {
-    "node": "16",
-    "npm": "8"
+    "node": "19",
+    "npm": "9"
   },
   "scripts": {
     "prebuild": "check-node-version --package",


### PR DESCRIPTION
Great plugin!

This updates the following:

nodejs: from v16 to v19
npm: from v8 to v9

Tested and confirmed working on Ubuntu 22.04.2 LTS, WordPress 6.1.1.