### PR TITLE
Fix unit tests and ensure that tests pass with twentytwentythree

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,7 +12,7 @@ jobs:
   php-tests:
     strategy:
       matrix:
-        php: [7.4, 8.0]
+        php: [8.0]
         wordpress: ["latest"]
     uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main
     with:

--- a/archiveless.php
+++ b/archiveless.php
@@ -3,9 +3,13 @@
  * Plugin Name: Archiveless
  * Plugin URI: https://github.com/alleyinteractive/archiveless
  * Description: Hide posts from archives performantly
- * Version: 0.1
+ * Version: 0.2
  * Author: Alley Interactive
  * Author URI: https://alley.co/
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Tested up to: 6.2
+ * Requires PHP: 8.0
  *
  * @package Archiveless
  *

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^1.0",
-        "mantle-framework/testkit": "^0.7"
+        "mantle-framework/testkit": "^0.10"
     },
     "config": {
         "allow-plugins": {

--- a/inc/class-archiveless.php
+++ b/inc/class-archiveless.php
@@ -391,7 +391,7 @@ class Archiveless {
 			array_keys(
 				get_post_stati(
 					[
-						'exclude_from_search' => false,
+						'public' => true,
 					]
 				)
 			)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,12 +6,13 @@
  */
 
 \Mantle\Testing\manager()
+	->maybe_rsync_plugin()
 	->loaded(
 		function () {
 			require_once __DIR__ . '/../archiveless.php';
-
+			// switch_theme( 'twentytwentytwo' );
 			// Set the permalink structure.
 			update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
-		} 
+		}
 	)
 	->install();


### PR DESCRIPTION
As time goes along, the date archive queries aren't testable in the same way they were back in 2021. The date archives and other archives don't have any posts in the main query and can't assert against `have_posts()`. This pull request will flip the test around to test against the response on the page instead of the result of `WP_Query`.