### PR TITLE
Misc: several updates to the plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+
+[*.{ts,tsx,js,jsx,scss,css,json,yaml,yml,feature,xml}]
+indent_style = space
+indent_size = 2
+
+# Dotfiles
+[.*]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,7 +12,7 @@ jobs:
   php-tests:
     strategy:
       matrix:
-        php: [8.0]
+        php: [8.0, 8.1, 8.2]
         wordpress: ["latest"]
     uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ All notable changes to this plugin will be documented in this file.
 - Composer: upgraded packages;
 - PHPStan: added support;
 - Bumped the plugin version from `0.2` to `1.1.2`;
-- Tested the plugin with the WordPress 6.4.
+- Tested the plugin with the WordPress 6.4;
+- Use `declare(strict_types=1);`, when possible;
+- Update Alley domain to `https://alley.com`;
+
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this plugin will be documented in this file.
 
+## 1.1.2
+
+- Github Action: Updated matrix to test the following PHP versions: 8.0, 8.1, and 8.2;
+- Added `.editorconfig`;
+- Composer: upgraded packages;
+- PHPStan: added support;
+- Bumped the plugin version from `0.2` to `1.1.2`;
+- Tested the plugin with the WordPress 6.4.
+
+## 1.1.1
+
+- See <https://github.com/alleyinteractive/archiveless/releases/tag/v1.1.1>
+
+### 1.1.0
+
+- See <https://github.com/alleyinteractive/archiveless/releases/tag/v1.1.0>
+
 ## 1.0.1
 
 - Bug fix from previous use of the archiveless plugin that broke backwards

--- a/archiveless.php
+++ b/archiveless.php
@@ -3,12 +3,12 @@
  * Plugin Name: Archiveless
  * Plugin URI: https://github.com/alleyinteractive/archiveless
  * Description: Hide posts from archives performantly
- * Version: 0.2
+ * Version: 1.1.2
  * Author: Alley Interactive
- * Author URI: https://alley.co/
+ * Author URI: https://alley.com
  * License: GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Tested up to: 6.2
+ * Tested up to: 6.4
  * Requires PHP: 8.0
  *
  * @package Archiveless
@@ -32,5 +32,10 @@
 require_once __DIR__ . '/inc/assets.php';
 require_once __DIR__ . '/inc/class-archiveless.php';
 
-// Add action hook to initialize the plugin.
-add_action( 'after_setup_theme', [ 'Archiveless', 'instance' ] );
+// Initialize Archiveless.
+add_action(
+	'after_setup_theme',
+	function (): void {
+		Archiveless::instance();
+	}
+);

--- a/composer.json
+++ b/composer.json
@@ -1,39 +1,48 @@
 {
-    "name": "alleyinteractive/archiveless",
-    "description": "WordPress plugin to hide posts from archives (lists)",
-    "homepage": "https://github.com/alleyinteractive/archiveless",
-    "type": "wordpress-plugin",
-    "license": "GPL-3.0-or-later",
-    "authors": [
-        {
-            "name": "Alley",
-            "email": "info@alley.co"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/alleyinteractive/archiveless/issues",
-        "source": "https://github.com/alleyinteractive/archiveless"
-    },
-    "require-dev": {
-        "alleyinteractive/alley-coding-standards": "^1.0",
-        "mantle-framework/testkit": "^0.10"
-    },
-    "config": {
-        "allow-plugins": {
-            "alleyinteractive/composer-wordpress-autoloader": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        },
-        "sort-packages": true
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "scripts": {
-        "phpcbf": "phpcbf .",
-        "phpcs": "phpcs .",
-        "phpunit": "phpunit",
-        "test": [
-            "@phpcs",
-            "@phpunit"
-        ]
+  "name": "alleyinteractive/archiveless",
+  "description": "WordPress plugin to hide posts from archives (lists)",
+  "keywords": [
+    "alleyinteractive",
+    "archive",
+    "archiveless"
+  ],
+  "homepage": "https://github.com/alleyinteractive/archiveless",
+  "type": "wordpress-plugin",
+  "license": "GPL-3.0-or-later",
+  "authors": [
+    {
+      "name": "Alley Interactive",
+      "email": "info@alley.com"
     }
+  ],
+  "support": {
+    "issues": "https://github.com/alleyinteractive/archiveless/issues",
+    "source": "https://github.com/alleyinteractive/archiveless"
+  },
+  "require-dev": {
+    "php": "^8.0",
+    "alleyinteractive/alley-coding-standards": "^2.0",
+    "mantle-framework/testkit": "^0.12",
+    "szepeviktor/phpstan-wordpress": "^1.1"
+  },
+  "config": {
+    "allow-plugins": {
+      "alleyinteractive/composer-wordpress-autoloader": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    },
+    "sort-packages": true
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "scripts": {
+    "phpcbf": "phpcbf .",
+    "phpcs": "phpcs .",
+    "phpunit": "phpunit",
+    "phpstan": "phpstan --memory-limit=512M",
+    "test": [
+      "@phpcs",
+      "@phpstan",
+      "@phpunit"
+    ]
+  }
 }

--- a/inc/class-archiveless.php
+++ b/inc/class-archiveless.php
@@ -5,6 +5,8 @@
  * @package Archiveless
  */
 
+declare(strict_types=1);
+
 /**
  * The main class for the Archiveless plugin.
  */
@@ -79,8 +81,8 @@ class Archiveless {
 	 *
 	 * @return Archiveless The active instance of the class.
 	 */
-	public static function instance() {
-		if ( ! isset( self::$instance ) ) {
+	public static function instance(): Archiveless {
+		if ( ! self::$instance instanceof Archiveless ) {
 			self::$instance = new Archiveless();
 		}
 		return self::$instance;
@@ -90,7 +92,7 @@ class Archiveless {
 	 * Determine if gutenberg editor exists and
 	 * the post type has support for the `custom-fields`.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function is_block_editor(): bool {
 		$is_block_editor = false;
@@ -113,35 +115,36 @@ class Archiveless {
 
 	/**
 	 * Register the custom post status.
+	 *
+	 * @see register_post_status().
 	 */
-	public function register_post_status() {
+	public function register_post_status(): void {
 		/**
 		 * Filters the arguments passed to `register_post_status()`.
 		 *
-		 * @see register_post_status().
+		 * @param array $args The arguments passed to `register_post_status()`.
 		 */
-		register_post_status(
-			self::$status,
-			apply_filters(
-				'archiveless_post_status_args',
-				[
-					'label'                     => __( 'Hidden from Archives', 'archiveless' ),
-					// translators: post count.
-					'label_count'               => _n_noop( 'Hidden from Archives <span class="count">(%s)</span>', 'Hidden from Archives <span class="count">(%s)</span>', 'archiveless' ),
-					'exclude_from_search'       => true,
-					'public'                    => true,
-					'publicly_queryable'        => true,
-					'show_in_admin_status_list' => true,
-					'show_in_admin_all_list'    => true,
-				]
-			)
+		$args = apply_filters(
+			'archiveless_post_status_args',
+			[
+				'label'                     => __( 'Hidden from Archives', 'archiveless' ),
+				// translators: post count.
+				'label_count'               => _n_noop( 'Hidden from Archives <span class="count">(%s)</span>', 'Hidden from Archives <span class="count">(%s)</span>', 'archiveless' ),
+				'exclude_from_search'       => true,
+				'public'                    => true,
+				'publicly_queryable'        => true,
+				'show_in_admin_status_list' => true,
+				'show_in_admin_all_list'    => true,
+			]
 		);
+
+		register_post_status( self::$status, $args );
 	}
 
 	/**
 	 * Register the custom post meta.
 	 */
-	public function register_post_meta() {
+	public function register_post_meta(): void {
 		register_post_meta(
 			'',
 			self::$meta_key,
@@ -157,8 +160,10 @@ class Archiveless {
 	/**
 	 * Add the checkbox to the post edit screen to give the option to hide a
 	 * post from archives.
+	 *
+	 * @global WP_Post $post The current post object.
 	 */
-	public function add_ui() {
+	public function add_ui(): void {
 		global $post;
 
 		// Ensure there is a post ID before attempting to look up postmeta.
@@ -186,7 +191,7 @@ class Archiveless {
 	 * @param string $meta_key    Metadata key.
 	 * @param mixed  $meta_value Metadata value. Serialized if non-scalar.
 	 */
-	public function updated_post_meta( $meta_id, $object_id, $meta_key, $meta_value ) {
+	public function updated_post_meta( $meta_id, $object_id, $meta_key, $meta_value ): void {
 		// Only handle updates to this plugin's meta key.
 		if ( self::$meta_key !== $meta_key ) {
 			return;
@@ -225,10 +230,8 @@ class Archiveless {
 
 	/**
 	 * Add a filter to all post types for REST response modification.
-	 *
-	 * @return void
 	 */
-	public function filter_rest_response() {
+	public function filter_rest_response(): void {
 		// Override the post status in the REST response to avoid Gutenbugs.
 		foreach ( get_post_types() as $allowed_post_type ) {
 			add_filter( 'rest_prepare_' . $allowed_post_type, [ $this, 'rest_prepare_post_data' ] );
@@ -241,7 +244,7 @@ class Archiveless {
 	 * @param WP_REST_Response $response The response object.
 	 * @return WP_REST_Response The modified response.
 	 */
-	public function rest_prepare_post_data( $response ) {
+	public function rest_prepare_post_data( $response ): WP_REST_Response {
 		// Override the post status if it is 'archiveless'.
 		if ( ! empty( $response->data['status'] ) && self::$status === $response->data['status'] ) {
 			$response->data['status'] = 'publish';
@@ -257,7 +260,7 @@ class Archiveless {
 	 * @param string  $old_status Old post status.
 	 * @param WP_Post $post       Post object.
 	 */
-	public function transition_post_status( $new_status, $old_status, $post ) {
+	public function transition_post_status( $new_status, $old_status, $post ): void {
 		// Only fire if transitioning to publish.
 		if ( 'publish' !== $new_status || $new_status === $old_status ) {
 			return;
@@ -270,15 +273,16 @@ class Archiveless {
 
 		// Change the post status to `archiveless` and update.
 		$post->post_status = self::$status;
+
 		wp_update_post( $post );
 	}
 
 	/**
 	 * Store the value of the "Hide form Archives" checkbox to post meta.
 	 *
-	 * @param  int $post_id Post ID.
+	 * @param int $post_id Post ID.
 	 */
-	public function save_post( $post_id ) {
+	public function save_post( $post_id ): void {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST[ self::$meta_key ] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
@@ -290,8 +294,10 @@ class Archiveless {
 	 * Fool the edit screen into thinking that an archiveless post status is
 	 * actually 'publish'. This lets WordPress use its hard-coded post statuses
 	 * seamlessly.
+	 *
+	 * @global WP_Post $post The current post object.
 	 */
-	public function fool_edit_form() {
+	public function fool_edit_form(): void {
 		global $post;
 
 		// Ensure there is a post status before attempting to set it.
@@ -310,9 +316,9 @@ class Archiveless {
 	 * Optionally allow archiveless posts to be hidden for other queries by
 	 * passing 'exclude_archiveless'.
 	 *
-	 * @param \WP_Query $query Current WP_Query object.
+	 * @param WP_Query $query Current WP_Query object.
 	 */
-	public function on_pre_get_posts( $query ) {
+	public function on_pre_get_posts( $query ): void {
 		// Ignore all post previews.
 		if ( $query->is_preview() || $query->get( 'p' ) ) {
 			return;
@@ -376,10 +382,10 @@ class Archiveless {
 	 * Retrieve the default post statuses to show for a request.
 	 * Imitates the default behavior of WP_Query.
 	 *
-	 * @param \WP_Query $query Current WP_Query object.
+	 * @param WP_Query $query Current WP_Query object.
 	 * @return string[]
 	 */
-	public function get_default_post_statuses( $query ) {
+	public function get_default_post_statuses( $query ): array {
 		$post_statuses = $query->get( 'post_status', [] );
 
 		if ( ! is_array( $post_statuses ) ) {
@@ -404,7 +410,7 @@ class Archiveless {
 	 * Output noindex meta tag to prevent search engines from indexing archiveless
 	 * posts.
 	 */
-	public function on_wp_head() {
+	public function on_wp_head(): void {
 		if ( ! is_singular() || ! static::is() ) {
 			return;
 		}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+  - vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+parameters:
+	# Level 9 is the highest level
+	level: max
+
+	paths:
+		- inc/
+		- archiveless.php

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,10 +9,10 @@
 	->maybe_rsync_plugin()
 	->loaded(
 		function () {
-			require_once __DIR__ . '/../archiveless.php';
-			// switch_theme( 'twentytwentytwo' );
 			// Set the permalink structure.
 			update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
+
+			require_once __DIR__ . '/../archiveless.php';
 		}
 	)
 	->install();


### PR DESCRIPTION
- Github Action: Updated matrix to test the following PHP versions: 8.0, 8.1, and 8.2;
- Added `.editorconfig`;
- Composer: upgraded packages;
- PHPStan: added support;
- Bumped the plugin version from `0.2` to `1.1.2`;
- Tested the plugin with the WordPress 6.4;
- Use `declare(strict_types=1);`, when possible;
- Update Alley domain to `https://alley.com`;
- Etc.