### PR TITLE
Handling `archiveless` posts in Elasticsearch plugins

### DIFF
--- a/inc/class-archiveless.php
+++ b/inc/class-archiveless.php
@@ -65,6 +65,10 @@ class Archiveless {
 		add_action( 'save_post', [ $this, 'save_post' ] );
 		add_action( 'wp_head', [ $this, 'on_wp_head' ] );
 
+		// Third-party plugin support.
+		add_filter( 'ep_indexable_post_status', [ $this, 'filter__elasticsearch_indexable_post_statuses' ] );
+		add_filter( 'sp_config_sync_statuses', [ $this, 'filter__elasticsearch_indexable_post_statuses' ] );
+
 		if ( is_admin() ) {
 			add_action( 'post_submitbox_misc_actions', [ $this, 'add_ui' ] );
 			add_action( 'add_meta_boxes', [ $this, 'fool_edit_form' ] );
@@ -72,6 +76,18 @@ class Archiveless {
 			// Later priority to mirror the previous use of posts_where.
 			add_action( 'pre_get_posts', [ $this, 'on_pre_get_posts' ], 20 );
 		}
+	}
+
+	/**
+	 * Add the `archiveless` post status to the list of indexable post statuses.
+	 *
+	 * @see <https://github.com/alleyinteractive/archiveless/issues/62>
+	 *
+	 * @param string[] $post_statuses The list of indexable post statuses.
+	 * @return string[]
+	 */
+	public function filter__elasticsearch_indexable_post_statuses( $post_statuses ): array {
+		return array_unique( array_merge( $post_statuses, [ self::$status ] ) );
 	}
 
 	/**


### PR DESCRIPTION
Toggling the "Hide from Archives" button obliterates a post from Elasticsearch. Not only hidden but literally gone.

This pull request changes this behavior for the VIP Search, ElasticPress, and SearchPress plugins. Ensuring the _archived_ posts are kept indexed in Elasticsearch.

Similar support was added to the Elasticsearch Extensions plugin: https://github.com/alleyinteractive/elasticsearch-extensions/pull/59

But if a site is not using it, this will ensure the _archived_ posts are kept indexed.

And since the Elasticsearch Extensions hook is run at a later priority, there is no possibility of the status being added here if the plugin restricts it. :)

fixes #62 